### PR TITLE
RBAC integeration

### DIFF
--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -12,6 +12,7 @@ spec:
       annotations:
         iam.amazonaws.com/role: cloud_sqs_autoscaler
     spec:
+      serviceAccountName: sqs-autoscaler-controller
       volumes:
         - name: ssl-certs
           hostPath:

--- a/rbac.yaml
+++ b/rbac.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: kube-system
+  name: sqs-autoscaler-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  namespace: kube-system
+  name: sqs-autoscaler-controller-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sqs-autoscaler-controller-role
+subjects:
+- kind: ServiceAccount
+  name: sqs-autoscaler-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  namespace: kube-system
+  name: sqs-autoscaler-controller-role
+rules:
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+- apiGroups:
+  - "aws.uswitch.com"
+  resources:
+  - sqsautoscalers
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  verbs:
+  - get
+  - update


### PR DESCRIPTION
Fixes https://github.com/uswitch/sqs-autoscaler-controller/issues/5 (copied RBAC from there)
By default all kubernetes clusters have RBAC enabled now. Good to keep RBAC in the default installation.